### PR TITLE
Fixed bug with requests containing binary data in body.

### DIFF
--- a/burp/BurpExtender.java
+++ b/burp/BurpExtender.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.Arrays;
 import javax.swing.JPanel;
 
 import javax.swing.SwingUtilities;
@@ -131,10 +132,7 @@ public class BurpExtender implements IBurpExtender, ISessionHandlingAction, ITab
         headers.add(newHeader);
         callbacks.printOutput("Added header: '" + newHeader + "'");
 
-        String request = new String(currentRequest.getRequest());
-        String messageBody = request.substring(rqInfo.getBodyOffset());
-        // rebuild message
-        byte[] message = helpers.buildHttpMessage(headers, messageBody.getBytes());
+        byte[] message = helpers.buildHttpMessage(headers, Arrays.copyOfRange(currentRequest.getRequest(), rqInfo.getBodyOffset(), currentRequest.getRequest().length));
         currentRequest.setRequest(message);
     }
     // end ISessionHandlingAction methods


### PR DESCRIPTION
It was identified that due to the request body being converted to a
String object, requests containing binary data in the body would be
malformed upon being processed by the plugin, potentially due to
encoding bugs(s). In order to avoid this issue, since the request body
is not processed at all, the conversion to a String object was replaced,
and the body is preserved in byte arrays.